### PR TITLE
細かい修正３（ユーザー登録機能）

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -21,4 +21,12 @@ class Address < ApplicationRecord
   validates :municipality, presence: true
   validates :street, presence: true
 
+  enum prefecture_d: {
+    default: 0,
+    hokkaido: 1,
+    iwate: 2,
+    akita: 3,
+    aomori: 4,
+  },  _prefix: true
+
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -17,16 +17,19 @@ class Address < ApplicationRecord
   # VALID_PHONE_REGEX = /\A[0-9]{10,11}\z/
   # validates :telephone_number, allow_blank: true, format: { with: VALID_PHONE_REGEX }
   
-  validates :prefecture_d, presence: true
+  validates :prefecture, presence: true
   validates :municipality, presence: true
   validates :street, presence: true
 
-  enum prefecture_d: {
-    default: 0,
-    hokkaido: 1,
-    iwate: 2,
-    akita: 3,
-    aomori: 4,
-  },  _prefix: true
+  enum prefecture: {
+    北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
+    茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,
+    新潟県:15,富山県:16,石川県:17,福井県:18,山梨県:19,長野県:20,
+    岐阜県:21,静岡県:22,愛知県:23,三重県:24,
+    滋賀県:25,京都府:26,大阪府:27,兵庫県:28,奈良県:29,和歌山県:30,
+    鳥取県:31,島根県:32,岡山県:33,広島県:34,山口県:35,
+    徳島県:36,香川県:37,愛媛県:38,高知県:39,
+    福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46,沖縄県:47
+  }
 
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -17,7 +17,7 @@ class Address < ApplicationRecord
   # VALID_PHONE_REGEX = /\A[0-9]{10,11}\z/
   # validates :telephone_number, allow_blank: true, format: { with: VALID_PHONE_REGEX }
   
-  validates :prefecture, presence: true
+  validates :prefecture_d, presence: true
   validates :municipality, presence: true
   validates :street, presence: true
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -50,7 +50,7 @@
       .field
         = f.label :生年月日
         %br/
-        = f.date_select :birthdate, use_month_numbers: true, start_year: 1940, end_year:2020, class: 'form_control'
+        = f.date_select :birthdate, use_month_numbers: true, start_year: 1940, end_year:2020, class: 'form_control', prompt:"--"
       .field
         = f.label :電話番号（半角で数字のみご記入願います）
         %br/

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -6,7 +6,7 @@
 
 %main.main
   %h2 住所情報登録
-  = form_for @address, local: true do |f|
+  = form_with model:@address, local: true do |f|
     = render "devise/shared/error_messages", resource: @address
     お届け先の情報を入力お願い致します。
     .field
@@ -32,7 +32,7 @@
     .field
       = f.label :県
       %br/
-      = f.select :prefecture_d, [["--", 0],["北海道", 1],["青森県", 2],["秋田県",3],["岩手県",4]]
+      = f.select :prefecture_d, options_for_select(Address.prefecture_ds.keys)
     .field
       = f.label :市区町村
       %br/

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -32,7 +32,7 @@
     .field
       = f.label :県
       %br/
-      = f.select :prefecture, Address.prefectures.keys, {prompt: '選択してください'}, class: 'form-control btn btn-info'
+      = f.select :prefecture, Address.prefectures.keys, prompt: '選択してください', class: 'form-control btn btn-info'
     .field
       = f.label :市区町村
       %br/

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -6,7 +6,7 @@
 
 %main.main
   %h2 住所情報登録
-  = form_for @address do |f|
+  = form_for @address, local: true do |f|
     = render "devise/shared/error_messages", resource: @address
     お届け先の情報を入力お願い致します。
     .field
@@ -32,7 +32,7 @@
     .field
       = f.label :県
       %br/
-      = f.text_field :prefecture
+      = f.select :prefecture_d, [["--", 0],["北海道", 1],["青森県", 2],["秋田県",3],["岩手県",4]]
     .field
       = f.label :市区町村
       %br/

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -32,7 +32,7 @@
     .field
       = f.label :県
       %br/
-      = f.select :prefecture_d, options_for_select(Address.prefecture_ds.keys)
+      = f.select :prefecture, Address.prefectures.keys, {prompt: '選択してください'}, class: 'form-control btn btn-info'
     .field
       = f.label :市区町村
       %br/

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,8 +8,8 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
-    - if notice
-      %p= notice
-    - if alert
-      %p= alert
+    -# - if notice
+    -#   %p= notice 
+    -# - if alert
+    -#   %p= alert
     = yield

--- a/db/migrate/20200313005801_create_addresses.rb
+++ b/db/migrate/20200313005801_create_addresses.rb
@@ -8,7 +8,7 @@ class CreateAddresses < ActiveRecord::Migration[5.2]
       t.string :lastname_kana,   null: false
       t.string :firstname_kana,  null: false
       t.text :postal_code,        null: false
-      t.text :prefecture,        null: false
+      t.integer :prefecture_d,        null: false
       t.text :municipality,      null: false
       t.text :street,            null: false
       t.text :building

--- a/db/migrate/20200313005801_create_addresses.rb
+++ b/db/migrate/20200313005801_create_addresses.rb
@@ -8,7 +8,7 @@ class CreateAddresses < ActiveRecord::Migration[5.2]
       t.string :lastname_kana,   null: false
       t.string :firstname_kana,  null: false
       t.text :postal_code,        null: false
-      t.integer :prefecture_d,        null: false
+      t.integer :prefecture,        null: false
       t.text :municipality,      null: false
       t.text :street,            null: false
       t.text :building

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2020_03_13_041045) do
     t.string "lastname_kana", null: false
     t.string "firstname_kana", null: false
     t.text "postal_code", null: false
-    t.integer "prefecture_d", default: 0, null: false
+    t.integer "prefecture", null: false
     t.text "municipality", null: false
     t.text "street", null: false
     t.text "building"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_19_102426) do
+ActiveRecord::Schema.define(version: 2020_03_13_041045) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2020_03_19_102426) do
     t.string "lastname_kana", null: false
     t.string "firstname_kana", null: false
     t.text "postal_code", null: false
-    t.text "prefecture", null: false
+    t.integer "prefecture_d", null: false
     t.text "municipality", null: false
     t.text "street", null: false
     t.text "building"
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 2020_03_19_102426) do
     t.text "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "ancestry：string：index"
   end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2020_03_13_041045) do
     t.string "lastname_kana", null: false
     t.string "firstname_kana", null: false
     t.text "postal_code", null: false
-    t.integer "prefecture_d", null: false
+    t.integer "prefecture_d", default: 0, null: false
     t.text "municipality", null: false
     t.text "street", null: false
     t.text "building"


### PR DESCRIPTION
スプリントレビューで指摘あった箇所を修正したのでマージする
１errorの全文が二箇所に表示されていたのを修正
２生年月日がデフォルトで日付を選択していたので初期値はハイフンにした
３県を入力してもらう仕様だったが、enumで整数をデータベースに保存するようにした。