### PR TITLE
Fix-Toppage-ByUserSignIn2

### DIFF
--- a/app/views/experiment/_header.html.haml
+++ b/app/views/experiment/_header.html.haml
@@ -20,7 +20,7 @@
         - if user_signed_in?
           = link_to destroy_user_session_path, class: "header__contents__bottom__right--tag" do
             ログアウト
-          = link_to sample_path, class: "header__contents__bottom__right--tag"
+          = link_to sample_path, class: "header__contents__bottom__right--tag" do
             サンプルページへ
             -# ↑作業用のページ。
         - else


### PR DESCRIPTION
# What
リンクのコードの後ろに「do」を付け足した。
# Why
SyntaxError となるため