### PR TITLE
WIP商品編集機能

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -50,14 +50,8 @@ $(document).on('turbolinks:load', ()=> {
         $('#previews').append(buildImg(targetIndex, blobUrl));
         }
       // fileIndexの先頭の数字を使ってinputを作る
-      if($('img').length <= 11){
       $('#image-box').append(buildFileField(fileIndex[0]));
       fileIndex.shift();
-      }
-      console.log($('strong').length)
-      $('strong').show();
-      $('strong:last').hide();
-
       // 末尾の数に1足した数を追加する
       fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
     }
@@ -66,34 +60,55 @@ $(document).on('turbolinks:load', ()=> {
   
   
   $('#image-box').on('click', '.js-remove', function() {
-    const targetIndex = $(this).parent().data('index')
-    // 該当indexを振られているチェックボックスを取得する
-    const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
-    // 削除を押した時、もしチェックボックスが存在すればチェックを入れる。:_destroyを送るため
-    if (hiddenCheck) hiddenCheck.prop('checked', true);
-    // 削除を押すとjs-file_groupを削除
-    $(this).parent().remove();
-    // imgも削除
-    $(`img[data-index="${targetIndex}"]`).remove();
     
-    // 画像入力欄が0個にならないようにしておく
-    if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
+    // 最後の削除ボタン、つまり新規投稿用の値の入っていないボタンが削除された時は反応させない。
+    // 新規フォームが作成されなくなる問題を防ぐため
+    if (($('.js-remove').index(this)) == ($('.js-remove').length) - 1){
+      console.log('新規投稿用のフォームは消さない')
+    }else{
+
+            const targetIndex = $(this).parent().data('index')
+            // 該当indexを振られているチェックボックスを取得する
+            const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
+            // 削除を押した時、もしチェックボックスが存在すればチェックを入れる。:_destroyを送るため
+            if (hiddenCheck) hiddenCheck.prop('checked', true);
+            // 削除を押すとjs-file_groupを削除
+            $(this).parent().remove();
+            // imgも削除
+            $(`img[data-index="${targetIndex}"]`).remove();
+            
+            
+
+            // 画像入力欄が0個にならないようにしておく
+            if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
+
+          }
+
   });
+
+
+  
 
   //画像がない時はボタンが無効に。画像がある時は有効に.
   $('#itembtn').on('mouseenter', function() {
     if ($('.js-file').length == 1) {
       $("#itembtn").attr("disabled", true);
-    }else{
-      $("#itembtn").attr('disabled', false);
+    }
+    // 11枚以上の時も同様に押せないようにした
+    if ($('.js-file').length >= 11) {
+      $("#itembtn").attr("disabled", true);
     }
   });
-  // 恐らくページ読み込み時に長さを取得してるため、上の有効化処理がマウスオーバーで発火しないので、画像ファイルに変化があれば発火してボタン有効化してる
+  // 恐らくページ読み込み時に長さを取得してるため、上の有効化処理がマウスオーバーで発火しないので、
+  // 画像ファイルに変化があるか、削除ボタンを押せば発火してボタン有効化してる
   // 上の記述も一応残しておくが、基本的に有効化はこっちが発火してる
   $('#image-box').on('change', '.js-file', function(e) {
     $("#itembtn").attr('disabled', false);
   });
-
+  $('#image-box').on('click', '.js-remove', function(e) {
+    $("#itembtn").attr('disabled', false);
+  });
+  
 
   // こっから先はカテゴリーのフォームに関する記述
 

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -56,6 +56,10 @@ $(document).on('turbolinks:load', ()=> {
       fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
     }
     
+    console.log($('strong').length)
+    $('strong').show()
+    $('strong:last').hide()
+
   });
   
   
@@ -101,7 +105,6 @@ $(document).on('turbolinks:load', ()=> {
   });
   // 恐らくページ読み込み時に長さを取得してるため、上の有効化処理がマウスオーバーで発火しないので、
   // 画像ファイルに変化があるか、削除ボタンを押せば発火してボタン有効化してる
-  // 上の記述も一応残しておくが、基本的に有効化はこっちが発火してる
   $('#image-box').on('change', '.js-file', function(e) {
     $("#itembtn").attr('disabled', false);
   });

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -92,6 +92,7 @@ before_action :set_item, except: [:index, :new, :create, :get_category_children,
 
 
   def update
+
     if @item.update(item_params)
       redirect_to root_path
     else

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -14,27 +14,27 @@
     %h1.mainh1 商品編集ページ 
     = form_for(@item, url: item_path) do |f|
 
-      -# .field
-      -#   = f.label :出品画像（１０枚まで）, class:"field__formlabel"
-      -#   %span.field__formspan 必須
-      -#   %br/
-      -#   #image-box
-      -#     #previews
-      -#       - if @item.persisted?
-      -#         - @item.images.each_with_index do |images, i|
-      -#           = image_tag images.image.url, data: { index: i }, width: "100", height: '100'
-      -#     = f.fields_for :images do |image|
-      -#       .js-file_group{"data-index" => "#{image.index}"}
-      -#         %i.fas.fa-camera 画像1
-      -#         = image.file_field :image, class:"js-file"
-      -#         %strong.js-remove 削除 
-      -#         - if @item.persisted?
-      -#           = image.check_box :_destroy, data:{ index: image.index }, class: 'hidden-destroy'
+      .field
+        = f.label :出品画像（１０枚まで）, class:"field__formlabel"
+        %span.field__formspan 必須
+        %br/
+        #image-box
+          #previews
+            - if @item.persisted?
+              - @item.images.each_with_index do |images, i|
+                = image_tag images.image.url, data: { index: i }, width: "100", height: '100'
+          = f.fields_for :images do |image|
+            .js-file_group{"data-index" => "#{image.index}"}
+              %i.fas.fa-camera 画像1
+              = image.file_field :image, class:"js-file"
+              %strong.js-remove 削除 
+              - if @item.persisted?
+                = image.check_box :_destroy, data:{ index: image.index }, class: 'hidden-destroy'
 
-      -#     - if @item.persisted?
-      -#       .js-file_group{"data-index" => "#{@item.images.count}"}
-      -#         =file_field_tag :image, name: "item[images_attributes][#{@item.images.count}][image]", class:'js-file'
-      -#         .js-remove 削除
+          - if @item.persisted?
+            .js-file_group{"data-index" => "#{@item.images.count}"}
+              =file_field_tag :image, name: "item[images_attributes][#{@item.images.count}][image]", class:'js-file'
+              .js-remove 削除
 
 
       .field

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -36,6 +36,7 @@
               .js-remove 削除
 
 
+
       .field
         = f.label :商品名, class:"field__formlabel"
         %span.field__formspan 必須


### PR DESCRIPTION
### what
商品編集機能の画像部分に取り掛かる前に商品登録の画像投稿で不具合が出る場合に対処。
（最新の新規投稿フォームを削除すると新しい物が生成されなく不具合を修正）
### why
フォームとロジックを使い回すにせよ、そうでないにせよ。投稿と編集は似通っているので別ブランチで作業したいため。