### PR TITLE
ExhibitionIcon-Fix1

### DIFF
--- a/app/views/experiment/_exhibitionIcon.html.haml
+++ b/app/views/experiment/_exhibitionIcon.html.haml
@@ -1,5 +1,7 @@
-= link_to new_item_path, class: "exhibition-icon" do
-  .exhibition-icon__btn
-    .exhibition-icon__btn-text
-      出品する
-    = image_tag "icon/icon_camera.png", class: "camera-icon"
+-if user_signed_in?
+  = link_to new_item_path, class: "exhibition-icon" do
+    .exhibition-icon__btn
+      .exhibition-icon__btn-text
+        出品する
+      = image_tag "icon/icon_camera.png", class: "camera-icon"
+-else


### PR DESCRIPTION
# What
出品ボタンをログインしている時には表示、未ログイン時には非表示にした。

#  Why
ログインしていないと出品できないようにするため。