### PR TITLE
Fix-ShowPageAndPickupCategory

### DIFF
--- a/app/assets/stylesheets/details-modules/details.scss
+++ b/app/assets/stylesheets/details-modules/details.scss
@@ -27,9 +27,13 @@
           }
         }
         &__sub {
-          &__list {
-            display: flex;
-            justify-content: start;
+          display: flex;
+          justify-content: center;
+          margin-top: 10px;
+
+          &__image {
+            height: 87px;
+            margin-right: 5px;
           }
         }
       }

--- a/app/views/experiment/_pickup-category.html.haml
+++ b/app/views/experiment/_pickup-category.html.haml
@@ -6,54 +6,52 @@
   .pickup__contents__list
 
     -if @item1 != nil
-      = link_to item_path(@item1), class: "" do
-        = image_tag @item1.images.first.image.url,  alt: '商品が投稿されていません'
-        %br
-        = "商品名#{@item1.name}"
-        %br 
-        = "価格#{@item1.price}"
+      = link_to item_path(@item1), class: "pickup__contents__list__product" do
+        .pickup__contents__list__product__image
+          = image_tag @item1.images.first.image.url,  alt: '商品が投稿されていません', class: 'product-image'
+        .pickup__contents__list__product__details
+          %h3.pickup__contents__list__product__details-name
+            = "#{@item1.name}"
+          .pickup__contents__list__product__details-contents
+            .price
+              = "#{@item1.price}円"
+            .evaluation
+              ★0
+          .pickup__contents__list__product__details-tax
+            （税込）
     -else
       = image_tag 'pict/観葉植物.jpeg', class: 'product-image'
     
     -if @item2 != nil
-      = link_to item_path(@item2), class: "" do
-        = image_tag @item2.images.first.image.url,  alt: '商品が投稿されていません'
-        %br  
-        = "商品名#{@item2.name}"
-        %br 
-        = "価格#{@item2.price}"      
+      = link_to item_path(@item2), class: "pickup__contents__list__product" do
+        .pickup__contents__list__product__image
+          = image_tag @item2.images.first.image.url,  alt: '商品が投稿されていません', class: 'product-image'
+        .pickup__contents__list__product__details
+          %h3.pickup__contents__list__product__details-name
+            = "#{@item2.name}"
+          .pickup__contents__list__product__details-contents
+            .price
+              = "#{@item2.price}円"
+            .evaluation
+              ★0
+          .pickup__contents__list__product__details-tax
+            （税込）
     -else
-      = image_tag 'pict/車.jpeg', class: 'product-image'
+      = image_tag 'pict/観葉植物.jpeg', class: 'product-image'
 
     -if @item3 != nil
-      = link_to item_path(@item3), class: "" do
-        = image_tag @item3.images.first.image.url,  alt: '商品が投稿されていません' 
-        %br  
-        = "商品名#{@item3.name}"
-        %br 
-        = "価格#{@item3.price}"
+      = link_to item_path(@item3), class: "pickup__contents__list__product" do
+        .pickup__contents__list__product__image
+          = image_tag @item3.images.first.image.url,  alt: '商品が投稿されていません', class: 'product-image'
+        .pickup__contents__list__product__details
+          %h3.pickup__contents__list__product__details-name
+            = "#{@item3.name}"
+          .pickup__contents__list__product__details-contents
+            .price
+              = "#{@item3.price}円"
+            .evaluation
+              ★0
+          .pickup__contents__list__product__details-tax
+            （税込）
     -else
-      = image_tag 'pict/アーモンドチョコ.jpeg', class: 'product-image'
-    
-    -# ↑最新の投稿三つの画像、名前、値段、詳細へのリンク
-    
-
-    -# カテゴリのリンク
-    -# フォームのロジックを元に作る予定。
-
-    -# = link_to item_path(@item1), class: "pickup__contents__list__product" do
-
-    -#   .pickup__contents__list__product__image
-    -#     = image_tag @item1.images.first.image.url,  alt: '商品が投稿されていません', class: 'product-image'
-    -#   .pickup__contents__list__product__details
-    -#     %h3.pickup__contents__list__product__details-name
-    -#       = @item1.name
-    -#     .pickup__contents__list__product__details-contents
-    -#       .price
-    -#         = @item1.price
-    -#       .evaluation
-    -#         ★0
-    -#     .pickup__contents__list__product__details-tax
-    -#       （税込）
-
-    -# ↑ とりあえず、３つ並べて同じページに飛ぶようにしている。
+      = image_tag 'pict/観葉植物.jpeg', class: 'product-image'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -6,17 +6,19 @@
     .details__contents__upper
       .details__contents__upper__ItemName
         = @item.name
+
       .details__contents__upper__ItemImageBox
         .details__contents__upper__ItemImageBox__main
-          - @item.images.each do |images|
-            = image_tag images.image.url ,class: 'details__contents__upper__ItemImageBox__main__image'
+          .details__contents__upper__ItemImageBox__main__image
+            出品ページで保存した画像の最初の画像を表示させたい
         .details__contents__upper__ItemImageBox__sub
-          %ul.details__contents__upper__ItemImageBox__sub__list
-            %li
-            %li
-            %li
+          - @item.images.each do |images|
+            = image_tag images.image.url, class: "details__contents__upper__ItemImageBox__sub__image"
+
       .details__contents__upper__ItemPrice
-        = @item.price
+        %h2
+          = "¥#{@item.price}"
+        %br
         %span （税込）
         %span 送料込み
       .details__contents__upper__ItemExplanation
@@ -28,33 +30,42 @@
             %p.details__contents__upper__Table__Box--Row--Cell--left
               出品者
             %p.details__contents__upper__Table__Box--Row--Cell
-              Shun
+              = @user.nickname
           .details__contents__upper__Table__Box--Row
             %p.details__contents__upper__Table__Box--Row--Cell--left
               カテゴリー
             %p.details__contents__upper__Table__Box--Row--Cell
               = link_to "#", class: "details__contents__upper__Table__Box--Row--Cell__link" do
                 = @item.parentcategory
+              %br
+              = link_to "#", class: "details__contents__upper__Table__Box--Row--Cell__link" do
+                = @child.name
+              %br
+              = link_to "#", class: "details__contents__upper__Table__Box--Row--Cell__link" do
+                = @grandchild.name
           .details__contents__upper__Table__Box--Row
             %p.details__contents__upper__Table__Box--Row--Cell--left
               ブランド
             %p.details__contents__upper__Table__Box--Row--Cell
-              = @item.brand
+              -if @item.brand != nil
+                = @item.brand
+              -else
+                = ""
           .details__contents__upper__Table__Box--Row
             %p.details__contents__upper__Table__Box--Row--Cell--left
               商品のサイズ
             %p.details__contents__upper__Table__Box--Row--Cell
-              = @item.size_id
+              = @size.name
           .details__contents__upper__Table__Box--Row
             %p.details__contents__upper__Table__Box--Row--Cell--left
               商品の状態
             %p.details__contents__upper__Table__Box--Row--Cell
-              = @item.condition_id
+              = @condition.name
           .details__contents__upper__Table__Box--Row
             %p.details__contents__upper__Table__Box--Row--Cell--left
               配送料の負担
             %p.details__contents__upper__Table__Box--Row--Cell
-              = @item.deliverycost_id
+              = @deliverycost.name
           .details__contents__upper__Table__Box--Row
             %p.details__contents__upper__Table__Box--Row--Cell--left
               発送元の地域
@@ -65,13 +76,12 @@
             %p.details__contents__upper__Table__Box--Row--Cell--left
               配送の方法
             %p.details__contents__upper__Table__Box--Row--Cell
-              = @item.deliveryway_id
+              = @item.deliveryway.name
           .details__contents__upper__Table__Box--Row
             %p.details__contents__upper__Table__Box--Row--Cell--left
               発送日の目安
             %p.details__contents__upper__Table__Box--Row--Cell
-              = @item.deliverytime_id
-
+              = @deliverytime.name
 
       .details__contents__upper__Button
         %button{type: "button", class: "details__contents__upper__Button__Love"}
@@ -102,26 +112,6 @@
 = render "experiment/footer"
 = render "experiment/exhibitionIcon"
 
--# =======
--# 商品詳細ページ
--# %br
--# %p 商品の情報は@itemに入ってるので.カラム名で取得してください
--# %p 追加で欲しい値とか変更して欲しいことあったら言ってください
-
--# %p 例
--# %p id
--# = @item.id
--# %p 商品名
--# = @item.name
--# %p 価格
--# = @item.price
--# %p 親カテゴリ
--# = @item.parentcategory
--# %p 子カテゴリ
--# = @child.name
--# %p 孫カテゴリ
--# = @grandchild.name
-
 
 -# ログインユーザーのものかで表示切り替え。マークアップ時はどの程度ページを差し替えるかによるけどパーシャルファイルを変えてレンダーした方がいいかもしれませんよ。
 - if user_signed_in?
@@ -138,30 +128,3 @@
 - else
   %p 購入リンクが表示される
   = link_to '商品購入へ(購入機能はまだ作ってないのでpathは仮置き)', '#'
-
-
--# %p 画像一覧
--# - @item.images.each do |images|
--#   = image_tag images.image.url 
-
-
-
-
--# -# 以下は例の部分で表示しなかったけどコードレビュー用に見本サイトにあった項目を表示してある物です。マークアップ担当者はこのあたり使いながらマークアップして見てください。
--# %p 出品者
--# = @user.nickname
--# %p ブランド
--# -if @item.brand != nil
--#   = @item.brand
--# %else
--#   = ""
--# %p 商品サイズ
--# = @size.name
--# %p 商品の状態
--# = @condition.name
--# %p 配送料の負担
--# = @deliverycost.name
--# %p 発送元の地域
--# = @item.delivery_from
--# %p 発送日の目安
--# = @deliverytime.name


### PR DESCRIPTION
# What
・トップページの「ピックアップカテゴリー」の見た目を修正。
・商品詳細ページの表（配送の詳細、カテゴリーなど）を、id ではなく 名前をちゃんと表示するように修正。

# Why
見本のビューのように整っていなかったから。
商品詳細ページへデータを受け渡せていなかったから。