### PR TITLE
Create-SoldOutFunction

### DIFF
--- a/app/assets/stylesheets/details-modules/details.scss
+++ b/app/assets/stylesheets/details-modules/details.scss
@@ -59,17 +59,18 @@
         width: 100%;
 
         &__link {
+          @include show-btn;
           display: block;
-          height: 40px;
-          line-height: 40px;
-          margin-bottom: 10px;
-          font-size: 24px;
           text-decoration: none;
-          background-color: $skyblue;
-          color: $white;
-          border-radius: 100px;
         }
         &__link:hover {
+          opacity: 0.5;
+        }
+        &__link--buy {
+          @include show-btn;
+          width: 100%;
+        }
+        &__link--buy:hover {
           opacity: 0.5;
         }
       }

--- a/app/assets/stylesheets/toppage-modules/_variables.scss
+++ b/app/assets/stylesheets/toppage-modules/_variables.scss
@@ -76,3 +76,13 @@ $heavy-gray: #dedede;
   vertical-align: middle;
   padding: 15px 15px;
 }
+
+@mixin show-btn {
+  height: 40px;
+  line-height: 40px;
+  margin-bottom: 10px;
+  font-size: 24px;
+  background-color: $skyblue;
+  color: $white;
+  border-radius: 100px;
+}

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,16 +1,6 @@
 
 = render "experiment/header"
 
--# 大丈夫だと思いますけどform_forから入れといてくださいね
-= form_for(@item, url: item_path) do |f|
-  .field
-    = f.hidden_field :auction, :value => false
-    = f.hidden_field :dealing, :value => false
-    = f.hidden_field :sold, :value => true
-  
-  = f.submit "これ押したらフラグ立つんで入れといてください", id:""
-
-
 .details
   .details__contents
     .details__contents__upper
@@ -41,7 +31,13 @@
           - else
             %p これが表示されることはないはず
         - else
-          = link_to '購入画面へ進む', '#', class: "details__contents__upper__ItemAction__link"
+          = form_for(@item, url: item_path) do |f|
+            .field
+              = f.hidden_field :auction, :value => false
+              = f.hidden_field :dealing, :value => false
+              = f.hidden_field :sold, :value => true
+            = f.submit "購入", class: "details__contents__upper__ItemAction__link--buy"
+
 
       .details__contents__upper__ItemExplanation
         = @item.description

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -33,9 +33,9 @@
         - else
           = form_for(@item, url: item_path) do |f|
             .field
-              = f.hidden_field :auction, :value => false
-              = f.hidden_field :dealing, :value => false
-              = f.hidden_field :sold, :value => true
+              = f.hidden_field :auction, value: false
+              = f.hidden_field :dealing, value: false
+              = f.hidden_field :sold, value: true
             = f.submit "購入", class: "details__contents__upper__ItemAction__link--buy"
 
 


### PR DESCRIPTION
# What
・「購入」ボタンの見た目を整えた。
・購入したものはトップページの一覧表示で表示されなくした。

# Why
売り切れたものが表示されなくなる機能があると、出品中かそうでないかがわかり便利になるから。
また、その機能を実装したらレイアウトが崩れたため、修正する必要があったから。